### PR TITLE
Added support for having different config across multiple loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
 ## Installation
-
+yarn users
 ```bash
 $ yarn add nestjs-winston-logger
+```
+
+npm users
+```bash
+$ npm install --save nestjs-winston-logger
 ```
 
 ## QuickStart
@@ -105,6 +110,81 @@ export class DemoService {
   constructor(@InjectLogger(DemoService.name) private logger: NestjsWinstonLoggerService) {}
 }
 ```
+
+### To use multiple loggers with different output config
+
+Sometimes there is a need to have separate kinds information write to separate logs.  For example, we don't necessarily want authentication logging inside a debug log.  Instead, we have a separate authentication.log file just for recording sign in/out requests.
+
+Inside demo.module.ts
+
+```ts
+import { Module } from "@nestjs/common";
+import { NestjsWinstonLoggerModule } from "nestjs-winston-logger";
+import { format, transports } from "winston";
+import { DemoService } from "./demo.service";
+import { AUTH_LOG } from "./demo.constants"
+
+function getLogConfig() {
+  const defaultConfig = {
+      format: format.combine(
+        format.timestamp({ format: "isoDateTime" }),
+        format.json(),
+        format.colorize({ all: true }),
+      ),
+      transports: [
+        new transports.File({ filename: "error.log", level: "error" }),
+        new transports.File({ filename: "combined.log" }),
+        new transports.Console(),
+      ],
+    };
+
+  let overrides:ContextOverrides = { };
+  overrides[AUTH_LOG] = {
+      ...defaultConfig,
+      transports: [
+        new transports.File({ filename: "authentication.log" })
+      ],
+    };
+
+  return {
+    defaultConfig: defaultConfig,
+    overrides: overrides
+  };
+}
+
+@Module({
+  imports: [
+    NestjsWinstonLoggerModule.forRoot(getLogConfig()),
+  ],
+  providers: [DemoService],
+})
+export class DemoModule {}
+```
+
+Inside login.service.ts
+
+```ts
+import { Injectable } from "@nestjs/common";
+import { NestjsWinstonLoggerService, InjectLogger } from "nestjs-winston-logger";
+import { AUTH_LOG } from "./demo.constants"
+
+@Injectable()
+export class LoginService {
+  constructor(
+    @InjectLogger(LoginService.name) private logger: NestjsWinstonLoggerService,
+    @InjectLogger(AUTH_LOG) private authLogger: NestjsWinstonLoggerService) {
+
+    authLogger.appendDefaultMeta('service', LoginService.name);
+  }
+}
+```
+
+## Why not just use nest-winston?
+
+[nest-winston](https://www.npmjs.com/package/nest-winston) is a populate package for providing basic integration between nest and winston.  However, many applications need more than just basic global logging.  nestjs-winston-logger provides fills in the following gaps from nest-winston by providing the following:
+
+* multiple logs with different configuration
+* request id metadata for each log message
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,37 +124,30 @@ import { format, transports } from "winston";
 import { DemoService } from "./demo.service";
 import { AUTH_LOG } from "./demo.constants"
 
-function getLogConfig() {
-  const defaultConfig = {
-      format: format.combine(
-        format.timestamp({ format: "isoDateTime" }),
-        format.json(),
-        format.colorize({ all: true }),
-      ),
-      transports: [
-        new transports.File({ filename: "error.log", level: "error" }),
-        new transports.File({ filename: "combined.log" }),
-        new transports.Console(),
-      ],
-    };
-
-  let overrides:ContextOverrides = { };
-  overrides[AUTH_LOG] = {
-      ...defaultConfig,
-      transports: [
-        new transports.File({ filename: "authentication.log" })
-      ],
-    };
-
-  return {
-    defaultConfig: defaultConfig,
-    overrides: overrides
+const defaultConfig = {
+    format: format.combine(
+      format.timestamp({ format: "isoDateTime" }),
+      format.json(),
+      format.colorize({ all: true }),
+    ),
+    transports: [
+      new transports.File({ filename: "error.log", level: "error" }),
+      new transports.File({ filename: "combined.log" }),
+      new transports.Console(),
+    ],
   };
-}
+
+let overrides:ContextOverrides = { };
+overrides[AUTH_LOG] = {
+    ...defaultConfig,
+    transports: [
+      new transports.File({ filename: "authentication.log" })
+    ],
+  };
 
 @Module({
   imports: [
-    NestjsWinstonLoggerModule.forRoot(getLogConfig()),
+    NestjsWinstonLoggerModule.forRoot(defaultConfig, overrides),
   ],
   providers: [DemoService],
 })
@@ -172,10 +165,7 @@ import { AUTH_LOG } from "./demo.constants"
 export class LoginService {
   constructor(
     @InjectLogger(LoginService.name) private logger: NestjsWinstonLoggerService,
-    @InjectLogger(AUTH_LOG) private authLogger: NestjsWinstonLoggerService) {
-
-    authLogger.appendDefaultMeta('service', LoginService.name);
-  }
+    @InjectLogger(AUTH_LOG, { service: LoginService.name}) private authLogger: NestjsWinstonLoggerService) { }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
@@ -27,7 +30,13 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
-  "dependencies": { },
+  "dependencies": {
+    "@nestjs/graphql": "^9.1.2",
+    "apollo-server-core": "^3.5.0",
+    "graphql": "15",
+    "morgan": "^1.10.0",
+    "winston": "^3.3.3"
+  },
   "devDependencies": {
     "@apollo/gateway": "^0.44.1",
     "@nestjs/cli": "^8.1.6",
@@ -42,16 +51,15 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
-    "rimraf": "^3.0.2",
     "ts-morph": "^13.0.2",
     "tsconfig-paths": "^3.12.0",
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
     "@nestjs/core": "^8.2.4",
-    "@nestjs/graphql": "^9.1.2",
-    "morgan": "^1.10.0",
-    "winston": "^3.3.3"
+    "@nestjs/platform-express": "^8.2.4",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-winston-logger",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "",
   "author": "Owen Siu",
   "license": "MIT",
@@ -19,9 +19,6 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
-    "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
@@ -30,13 +27,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
-  "dependencies": {
-    "@nestjs/graphql": "^9.1.2",
-    "apollo-server-core": "^3.5.0",
-    "graphql": "15",
-    "morgan": "^1.10.0",
-    "winston": "^3.3.3"
-  },
+  "dependencies": { },
   "devDependencies": {
     "@apollo/gateway": "^0.44.1",
     "@nestjs/cli": "^8.1.6",
@@ -51,15 +42,16 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
+    "rimraf": "^3.0.2",
     "ts-morph": "^13.0.2",
     "tsconfig-paths": "^3.12.0",
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
     "@nestjs/core": "^8.2.4",
-    "@nestjs/platform-express": "^8.2.4",
-    "reflect-metadata": "^0.1.13",
-    "rimraf": "^3.0.2"
+    "@nestjs/graphql": "^9.1.2",
+    "morgan": "^1.10.0",
+    "winston": "^3.3.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/nestjs-winston-logger.decorator.ts
+++ b/src/nestjs-winston-logger.decorator.ts
@@ -1,11 +1,13 @@
 import { Inject } from "@nestjs/common";
 import { NestjsWinstonLoggerService } from "./nestjs-winston-logger.service";
 
+type WinstonMetadata = { [key:string]: string | boolean | number };
+
 /**
  * Hold all unique logger context
  * @name loggerContexts
  */
-const loggerContexts = new Set<string>();
+const loggerContexts = new Map<string, WinstonMetadata>();
 
 /**
  * format unique provider token
@@ -19,11 +21,15 @@ export function getLoggerToken(context: string): string {
  * Custom decorator for easy inject LoggerService
  * @param context - prefer input your service name
  */
-export function InjectLogger(context = "") {
-  loggerContexts.add(context);
+export function InjectLogger(context = "", metadata: { [key:string]: string | boolean | number } = {}) {
+  loggerContexts.set(context, metadata);
   return Inject(getLoggerToken(context));
 }
 
+export function getLoggerContextMetadata(context: string) {
+  return loggerContexts.get(context);
+}
+
 export function getLoggerContexts() {
-  return [...loggerContexts.values()];
+  return [...loggerContexts.keys()];
 }

--- a/src/nestjs-winston-logger.service.ts
+++ b/src/nestjs-winston-logger.service.ts
@@ -4,7 +4,6 @@ import { NESTJS_WINSTON_CONFIG_OPTIONS } from "./nestjs-winston-logger.constants
 
 export type LoggerContext = {
   service?:string,
-  context?:string,
   [key:string]:string | number | boolean
 }
 

--- a/src/nestjs-winston-logger.service.ts
+++ b/src/nestjs-winston-logger.service.ts
@@ -2,6 +2,12 @@ import { Inject, Injectable, ConsoleLogger, Scope } from "@nestjs/common";
 import { createLogger, LoggerOptions, Logger as WinstonLogger } from "winston";
 import { NESTJS_WINSTON_CONFIG_OPTIONS } from "./nestjs-winston-logger.constants";
 
+export type LoggerContext = {
+  service?:string,
+  context?:string,
+  [key:string]:string | number | boolean
+}
+
 @Injectable({ scope: Scope.TRANSIENT })
 export class NestjsWinstonLoggerService extends ConsoleLogger {
   private logger: WinstonLogger;
@@ -11,10 +17,18 @@ export class NestjsWinstonLoggerService extends ConsoleLogger {
     this.logger = createLogger(config);
   }
 
-  setContext(serviceName: string) {
+  setContext(context: string | LoggerContext) {
+    if (typeof context === 'string') {
+      this.logger.defaultMeta = {
+        ...this.logger.defaultMeta,
+        service: context,
+      };
+      return;
+    }
+
     this.logger.defaultMeta = {
       ...this.logger.defaultMeta,
-      service: serviceName,
+      ...context
     };
   }
 


### PR DESCRIPTION
I saw your comment about mongoose but I didn't quite understand what specifically you would like to see that is similar to mongoose.  Please feel free to let me know on the code review and I'll make the appropriate changes.

As it stands, the method I originally posted in the comment seems to be working ok.  I also did a couple other changes which perhaps I should not have included in this commit but just give me your feedback and I can change/revert.

Questionable changes
* README.md - I added a comparison to nest-winston.  Personally, I feel your library is better for my needs but for other people wondering the same, it would be good to specifically call out why they might choose to use a less popular library
* package.json - I moved several dependencies to peerDependencies.  I believe this is where they belong for a support package

Lastly, it might be worth considering making morgan and graphql optional dependencies.  This is because some people may want to use the library without morgan or perhaps for rest just controllers.  In those cases, we don't need the extra dependencies.

